### PR TITLE
extend and use the official `resty.aes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
 # WXBizMsgCrypt
 
-模仿[微信公众平台加密解密技术方案](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419318482&lang=zh_CN)
-写了一个openresty 版的加密解密。
+[the WeChat Message Cryptography](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419318482&lang=zh_CN) in the openresty lua verison.
 
-注意点：
-aes.lua不是openresty 主版本的，而是用了这个[no padding](https://github.com/openresty/lua-resty-string/pull/35)
+## aes_pad.lua
+
+extend the [aes.lua](https://github.com/openresty/lua-resty-string) with a `set_padding` method, [discussing here](https://github.com/openresty/lua-resty-string/pull/35)
+
+## crypt.lua
+
+`encrypt(text, timestamp, nonce)`
+
+`decrypt(text_encrypted)`
+
+`get_sha1({token, timestamp, nonce, text_encrypted})`
+
+## Synopsis
+
+```lua
+# nginx.conf:
+
+server {
+    location = /test {
+        content_by_lua_block {
+            local token = "pamtest"
+            local aesKey = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG"
+            local timestamp = "1409304348"
+            local nonce = "xxxxxx"
+            local appId = "wxb11529c136998cb6"
+            local sample = "<xml><ToUserName><![CDATA[oia2Tj我是中文jewbmiOUlr6X-1crbLOvLw]]></ToUserName><FromUserName><![CDATA[gh_7f083739789a]]></FromUserName><CreateTime>1407743423</CreateTime><MsgType><![CDATA[video]]></MsgType><Video><MediaId><![CDATA[eYJ1MbwPRJtOvIEabaxHs7TX2D-HV71s79GUxqdUkjm6Gs2Ed1KF3ulAOA9H1xG0]]></MediaId><Title><![CDATA[testCallBackReplyVideo]]></Title><Description><![CDATA[testCallBackReplyVideo]]></Description></Video></xml>"
+
+            local crypt = require "resty.crypt"
+            local wxmc = crypt:new(token, aesKey, appId)
+            local encrypted = wxmc:encrypt(sample, timestamp, nonce)
+            ngx.say("the sample encrypted: ", encrypted)
+
+            local gsub = ngx.re.gsub
+            sample = gsub(encrypted, [=[.*<Encrypt>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</Encrypt>.*]=], "$1")
+	        ngx.say("the sample decrypted: ", wxmc:decrypt(sample))
+        }
+    }
+}
+```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ server {
 
             local gsub = ngx.re.gsub
             sample = gsub(encrypted, [=[.*<Encrypt>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</Encrypt>.*]=], "$1")
-	        ngx.say("the sample decrypted: ", wxmc:decrypt(sample))
+            ngx.say("the sample decrypted: ", wxmc:decrypt(sample))
         }
     }
 }

--- a/lib/resty/aes_pad.lua
+++ b/lib/resty/aes_pad.lua
@@ -1,0 +1,28 @@
+-- patched
+-- @see https://github.com/openresty/lua-resty-string/pull/35
+
+local aes = require "resty.aes"
+local ffi = require "ffi"
+local C = ffi.C
+ffi.cdef[[
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+
+int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad);
+]]
+
+-- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L569-L576
+function aes.set_padding(self, pad)
+    if self._encrypt_ctx == nil or self._decrypt_ctx == nil then
+        return nil, "the aes instance doesn't existed"
+    end
+
+    -- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L402-L410
+    C.EVP_CIPHER_CTX_set_padding(self._encrypt_ctx, pad)
+
+    -- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L515-L523
+    C.EVP_CIPHER_CTX_set_padding(self._decrypt_ctx, pad)
+
+    return 1
+end
+
+return aes

--- a/lib/resty/aes_pad.lua
+++ b/lib/resty/aes_pad.lua
@@ -12,15 +12,17 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad);
 
 -- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L569-L576
 function aes.set_padding(self, pad)
-    if self._encrypt_ctx == nil or self._decrypt_ctx == nil then
+    local encrypt_ctx, decrypt_ctx = self._encrypt_ctx, self._decrypt_ctx
+
+    if encrypt_ctx == nil or decrypt_ctx == nil then
         return nil, "the aes instance doesn't existed"
     end
 
     -- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L402-L410
-    C.EVP_CIPHER_CTX_set_padding(self._encrypt_ctx, pad)
+    C.EVP_CIPHER_CTX_set_padding(encrypt_ctx, pad)
 
     -- @link https://github.com/openssl/openssl/blob/master/crypto/evp/evp_enc.c#L515-L523
-    C.EVP_CIPHER_CTX_set_padding(self._decrypt_ctx, pad)
+    C.EVP_CIPHER_CTX_set_padding(decrypt_ctx, pad)
 
     return 1
 end

--- a/lib/resty/crypt.lua
+++ b/lib/resty/crypt.lua
@@ -82,7 +82,7 @@ function _M.decrypt (self, encrypted)
     local aes_crypt = assert(
         aes:new(self.aes_key, nil, self.cipher, {iv = self.iv})
     )
-    aes:set_padding(0)
+    aes_crypt:set_padding(0)
 
     local text = aes_crypt:decrypt(ciphertext_dec)
     text = pkcs7_decode(string.sub(text, 17, #text))
@@ -102,7 +102,7 @@ function _M.encrypt (self, text, timestamp, nonce)
     local aes_crypt = assert(
         aes:new(self.aes_key, nil, self.cipher, {iv = self.iv})
     )
-    aes:set_padding(0)
+    aes_crypt:set_padding(0)
 
     local encrypted = ngx.encode_base64(aes_crypt:encrypt(text))
     local signature = self:get_sha1({self.token, timestamp, nonce, encrypted})

--- a/lib/resty/crypt.lua
+++ b/lib/resty/crypt.lua
@@ -56,12 +56,11 @@ function _M.new (self, token, aes_key, app_id)
 end
 
 function _M.get_sha1 (self, sha1_table)
-    table.sort(sha1_table)
+    local tb_sort = table.sort
+    tb_sort(sha1_table)
 
-    local to_sha1 = ""
-    for k,v in pairs(sha1_table) do
-        to_sha1 = to_sha1 .. v
-    end
+    local tb_join = table.concat
+    local to_sha1 = tb_join(sha1_table)
 
     local sha1 = resty_sha1:new()
     sha1:update(to_sha1)


### PR DESCRIPTION
[aes no padding](https://github.com/openresty/lua-resty-string/pull/35) 的扩展版本，代码另做了少许优化。